### PR TITLE
CLEANUP: Make linter happy and test

### DIFF
--- a/doc/intf/olo_intf_i2c_master.md
+++ b/doc/intf/olo_intf_i2c_master.md
@@ -46,6 +46,8 @@ The user has three main interfaces:
 - On the status interface (_Status_..._) the user can see if the I2C bus is currently busy or free and if a command
   timed out (i.e. the user failed to provide the next command within time, and hence the bus was released).
 
+The I2C SCL clock frequency can optionally be changed with every start condition transmitted.
+
 For constants containing the command codes, a package _olo_intf_i2c_master_pkg_ is defined in the same VHDL file.
 
 **Note:** The I2C ports must be constrained manually. No solution was found for scoped timing constraints for inferred
@@ -57,7 +59,7 @@ tristate buffers.
 | :----------------- | :------ | ------- | :----------------------------------------------------------- |
 | ClkFrequency_g     | real    | -       | Frequency of the clock _Clk_ in Hz.<br />For correct operation, the clock frequency must be at least 16x higher than the I2C bus frequency. |
 | I2cFrequency_g     | real    | 100.0e3 | Frequency of the _I2cScl_ signal in Hz (without clock division) |
-| ClkDivBits_g       | integer | 0       | Number of bits used for the _Cmd_ClkDiv_ port width. If this value is set to 0, the SCL clock divider is disabled.
+| ClkDivBits_g       | natural | 0       | Number of bits used for the _Cmd_ClkDiv_ port width. If this value is set to 0, the SCL clock divider is disabled. |
 | BusBusyTimeout_g   | real    | 1.0e-3  | If _I2cScl_ = '1' and _I2cSda_ = '1' for this time in sec., the bus is regarded as free. If the user does not provide any command for this time, the _olo_intf_i2c\_master_ automatically generates a stop-condition to release the bus. |
 | CmdTimeout_g       | real    | 1.0e-3  | When the _olo_intf\_i2c\_master_ is ready for the next command but the user does not provide a new command, after this timeout (in sec.) the bus is releases and _Status_CmdTo_ is pulsed to inform the user. |
 | InternalTriState_g | boolean | true    | **True** = Use internal tri-state buffer (_I2cScl_ and _I2cSda_) are used. <br />**False** = Use external tri-state buffer (_I2cScl\_x_ and _I2cSda\_x_) are used. |
@@ -81,7 +83,7 @@ tristate buffers.
 | Cmd_Command     | in     | 3               | -       | Command to execute (_olo_intf_i2c_master_pkg_  constant names in brackets)<br />"000" =\> Send startcondition (_I2cCmd_Start_c_)<br />"001" =\> Send stop condition (_I2cCmd_Stop_c_)<br />"010" =\> Send rep. start condition"  (_I2cCmd_RepStart_c_)   <br />"011" =\> Send data  byte (_I2cCmd_Send_c_) <br />"100" =\> Receive data byte  (_I2cCmd_Receive_c_) |
 | Cmd_Data        | in     | 8               | -       | Data to send (only for _I2cCmd_Send_c_  resp. _Cmd_Command="011"_). |
 | Cmd_Ack         | in     | 1               |         | Acknowledge to send (only for _I2cCmd_Receive_c_ resp. _Cmd_Command="100")._<br />**'1'** =\> send ACK , **'0'** =\> send NACK. <br />**Note that polarity is inverted compared to the acknowledge bit on the I2C bus.** |
-| Cmd_ClkDiv      | in     | ClkDivBits_g    | '0'     | Runtime clock divider value for SCL clock. If _ClkDivBits_g_ > 0, the SCL frequency _I2cFrequency_g_ is divided by the _Cmd_ClkDiv_ value (converted to unsigned). No division is applied when _Cmd_ClkDiv_ = "0". |
+| Cmd_ClkDiv      | in     | ClkDivBits_g    | '0'     | Runtime clock divider value for SCL clock. If _ClkDivBits_g_ > 0, the SCL frequency _I2cFrequency_g_ is divided by _Cmd_ClkDiv_ . _Cmd_ClkDiv_ is latched for every _I2cCmd_Start_c_ command. <br> Examples:<br> 0 -> _I2cFrequency_g_ <br> 1 -> _I2cFrequency_g_ <br> 2 -> _I2cFrequency_g_ / 2 <br> 10 -> _I2cFrequency_g_ / 10 <br> |
 
 ### Response Interface
 

--- a/src/intf/vhdl/olo_intf_i2c_master.vhd
+++ b/src/intf/vhdl/olo_intf_i2c_master.vhd
@@ -59,7 +59,7 @@ entity olo_intf_i2c_master is
     generic (
         ClkFrequency_g      : real;
         I2cFrequency_g      : real    := 100.0e3;
-        ClkDivBits_g        : integer := 0;
+        ClkDivBits_g        : natural := 0;
         BusBusyTimeout_g    : real    := 1.0e-3;
         CmdTimeout_g        : real    := 1.0e-3;
         InternalTriState_g  : boolean := true;
@@ -90,10 +90,10 @@ entity olo_intf_i2c_master is
         I2c_Scl         : inout std_logic;
         I2c_Sda         : inout std_logic;
         -- I2c Interface with external Tri-State
-        I2c_Scl_i       : in    std_logic := '0';
+        I2c_Scl_i       : in    std_logic                                   := '0';
         I2c_Scl_o       : out   std_logic;
         I2c_Scl_t       : out   std_logic;
-        I2c_Sda_i       : in    std_logic := '0';
+        I2c_Sda_i       : in    std_logic                                   := '0';
         I2c_Sda_o       : out   std_logic;
         I2c_Sda_t       : out   std_logic
     );
@@ -184,8 +184,8 @@ begin
         v.QPeriodTick := '0';
         if (r.Fsm = BusIdle_s) or (r.Fsm = BusBusy_s) then
             v.QuartPeriodCnt := (others => '0');
-            v.ClkDivCnt := to_unsigned(1, ClkDivBits_g);
-        elsif r.ClkDivCnt = r.CmdClkDivLatch or ClkDivBits_g = 0 then
+            v.ClkDivCnt      := to_unsigned(1, ClkDivBits_g);
+        elsif r.ClkDivCnt >= r.CmdClkDivLatch or ClkDivBits_g = 0 then
             v.ClkDivCnt := to_unsigned(1, ClkDivBits_g);
             if r.QuartPeriodCnt = QuarterPeriodLimit_c then
                 v.QuartPeriodCnt := (others => '0');
@@ -306,7 +306,7 @@ begin
                 -- Handle Clock Stretching in case of a repeated start (slave keeps SCL low)
                 if I2cScl_Sync = '0' and r.CmdTypeLatch = I2cCmd_RepStart_c then
                     v.QuartPeriodCnt := (others => '0');
-                    v.ClkDivCnt := to_unsigned(1, ClkDivBits_g);
+                    v.ClkDivCnt      := to_unsigned(1, ClkDivBits_g);
                 end if;
 
                 -- Handle Arbitration (other master transmits start condition first)
@@ -456,7 +456,7 @@ begin
                 -- Handle Clock Stretching (slave keeps SCL low)
                 if I2cScl_Sync = '0' then
                     v.QuartPeriodCnt := (others => '0');
-                    v.ClkDivCnt := to_unsigned(1, ClkDivBits_g);
+                    v.ClkDivCnt      := to_unsigned(1, ClkDivBits_g);
                 end if;
 
                 -- Handle Arbitration for Sending (only databits, not ack)
@@ -520,7 +520,7 @@ begin
                 -- Handle Clock Stretching (slave keeps SCL low)
                 if I2cScl_Sync = '0' then
                     v.QuartPeriodCnt := (others => '0');
-                    v.ClkDivCnt := to_unsigned(1, ClkDivBits_g);
+                    v.ClkDivCnt      := to_unsigned(1, ClkDivBits_g);
                 end if;
 
             when Stop3_s =>

--- a/test/tb/olo_test_i2c_vc.vhd
+++ b/test/tb/olo_test_i2c_vc.vhd
@@ -1027,7 +1027,7 @@ begin
                 else
                     expect_byte_excl_clock(data_slv, scl, sda,
                                            to_string(msg_p) & " - Receive byte in slave mode [I2cExpectRxByte]",
-                                           timeout => timeout,
+                                           timeout     => timeout,
                                            clk_stretch => clk_stretch);
                     send_bit_excl_clock(ack_output, scl, sda,
                                         to_string(msg_p) & " - ACK in slave mode [I2cExpectRxByte]",


### PR DESCRIPTION
I also changed the comparison of ClkDivCnt to >= (the = could fail if the ClkDivCnt is reduced to a smaller value).